### PR TITLE
Enforce execution address is provided

### DIFF
--- a/staking_deposit/cli/generate_keys.py
+++ b/staking_deposit/cli/generate_keys.py
@@ -100,9 +100,9 @@ def generate_keys_arguments_decorator(function: Callable[..., Any]) -> Callable[
                 lambda: load_text(['arg_execution_address', 'confirm'], func='generate_keys_arguments_decorator'),
                 lambda: load_text(['arg_execution_address', 'mismatch'], func='generate_keys_arguments_decorator'),
             ),
-            default=None,
             help=lambda: load_text(['arg_execution_address', 'help'], func='generate_keys_arguments_decorator'),
             param_decls=['--execution_address', '--eth1_withdrawal_address'],
+            prompt=lambda: load_text(['arg_execution_address', 'prompt'], func='generate_keys_arguments_decorator'),
         ),
     ]
     for decorator in reversed(decorators):


### PR DESCRIPTION
From now, `staking-deposit-cli` enforces user to provide execution address to generate withdrawal credentials.